### PR TITLE
Improve modal responsivity

### DIFF
--- a/src/components/Modal/styles.css
+++ b/src/components/Modal/styles.css
@@ -21,6 +21,7 @@
 }
 
 .modal {
+  min-width: 50rem;
   max-width: 100rem;
   max-height: 70vh;
   min-height: 36vh;
@@ -56,4 +57,10 @@
 
 .modalTitle {
   margin-bottom: var(--spacing-2);
+}
+
+@media screen and (max-width: 50rem) {
+  .modal {
+    min-width: 100%;
+  }
 }

--- a/src/components/Modal/styles.css
+++ b/src/components/Modal/styles.css
@@ -21,7 +21,6 @@
 }
 
 .modal {
-  min-width: 50rem;
   max-width: 100rem;
   max-height: 70vh;
   min-height: 36vh;

--- a/src/components/Modal/styles.css
+++ b/src/components/Modal/styles.css
@@ -6,7 +6,7 @@
   left: 0;
   display: flex;
   justify-content: center;
-  align-items: center;
+  padding-top: 15vh;
   z-index: var(--z-index-big);
   transition: all 0.2s;
   background-color: rgba(0, 0, 0, 0.3);
@@ -59,8 +59,13 @@
   margin-bottom: var(--spacing-2);
 }
 
-@media screen and (max-width: 50rem) {
+@media screen and (max-width: 560px) {
   .modal {
     min-width: 100%;
+    min-height: 100%;
+  }
+
+  .modalWrapper {
+    padding-top: 0;
   }
 }


### PR DESCRIPTION
This PR removes the property of `align-items: center` from the modal wrapper and uses padding top instead to position the modal closer to the top of the screen, thus improving the readability. It also sets the modal to occupy the entire screen on extra small screens.
 
closes #35 