### PR TITLE
Style tweaks and custom link renderer

### DIFF
--- a/src/components/Link/Link.jsx
+++ b/src/components/Link/Link.jsx
@@ -1,18 +1,32 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styles from "./styles.css";
+import { classNames } from "../../utils";
 
-const Link = ({ href, children }) => {
+const DefaultLinkComponent = ({ children, ...props }) => (
+  <a {...props}>{children}</a>
+);
+
+DefaultLinkComponent.propTypes = {
+  children: PropTypes.node
+};
+
+const Link = ({ gray, className, customComponent, children, ...props }) => {
+  const Comp = customComponent || DefaultLinkComponent;
   return (
-    <a className={styles.link} href={href}>
+    <Comp
+      className={classNames(styles.link, gray && styles.gray, className)}
+      {...props}>
       {children}
-    </a>
+    </Comp>
   );
 };
 
 Link.propTypes = {
-  href: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired
+  customComponent: PropTypes.node,
+  children: PropTypes.node,
+  gray: PropTypes.bool,
+  className: PropTypes.string
 };
 
 export default Link;

--- a/src/components/Link/styles.css
+++ b/src/components/Link/styles.css
@@ -1,3 +1,12 @@
 .link {
   color: var(--color-primary);
+  font-weight: var(--font-weight-regular);
+}
+
+.gray {
+  color: var(--color-gray);
+}
+
+.link:hover {
+  font-weight: var(--font-weight-semi-bold);
 }

--- a/src/components/TextInput/styles.css
+++ b/src/components/TextInput/styles.css
@@ -24,6 +24,7 @@
   left: 0;
   color: var(--color-gray);
   font-size: var(--font-size-normal);
+  font-weight: var(--font-weight-regular);
   transition: all 0.25s;
 }
 

--- a/src/docs/link.mdx
+++ b/src/docs/link.mdx
@@ -15,6 +15,21 @@ import { Link } from "../index";
 
 ## Usage
 
+### Simple link
 <Playground>
   <Link href="#">Click me</Link>
 </Playground>
+
+### Simple grey link
+<Playground>
+  <Link gray href="#">Click me</Link>
+</Playground>
+
+### Link with a custom element 
+This is useful for specifying a custom element such as a React-Router Link
+
+<Playground>
+  <Link href="#" customComponent={(props) => <div {...props} />}>Click me</Link>
+</Playground>
+
+

--- a/src/theme/lightTheme.js
+++ b/src/theme/lightTheme.js
@@ -10,6 +10,7 @@ const lightTheme = {
   "color-gold": "#cfa03f",
   "color-yellow": "#ffc84e",
   "color-yellow-light": "#ffe4a7",
+  "color-gray-blueish": "#596D81",
   "color-gray-dark": "#3d5873",
   "color-gray": "#8997a5",
   "color-gray-light": "#c4cbd2",

--- a/src/theme/lightTheme.js
+++ b/src/theme/lightTheme.js
@@ -29,8 +29,8 @@ const lightTheme = {
   "font-size-xxlarge": "2.6rem",
   "font-size-xlarge": "2.3rem",
   "font-size-large": "2rem",
-  "font-size-normal": "1.7rem",
-  "font-size-small": "1.5rem",
+  "font-size-normal": "1.6rem",
+  "font-size-small": "1.3rem",
 
   "font-weight-extra-light": "200",
   "font-weight-light": "300",


### PR DESCRIPTION
This PR tweak a few things as required per this [comment](https://github.com/decred/politeiagui/pull/1251#issuecomment-500001149):

- Change regular font-size from 17px to 16px
- Change small font-size from 15px to 13px
- Make sure text-input is not using font semi-bold
- Allow Links to have a custom render element (useful for specifying the `react-router-dom` Link)